### PR TITLE
add a package argument to help_console

### DIFF
--- a/R/help_console.R
+++ b/R/help_console.R
@@ -15,6 +15,7 @@
 #'"as is" rather than in a code or verbatim environment
 #'@param lines Optional. An integer vector specifying which lines to print
 #'@param before,after Text to insert before or after the help file, such as
+#'@param package A character string containing the package name to search. Necessary if two packages share a function name.
 #'\code{<quote>} and \code{</quote>} for printing the text as quoted HTML  
 #'@export
 #'@import tools
@@ -22,10 +23,10 @@
 #'txt <- help_console(c)
 #'help_console(optim, "html", lines=1:25, before="<quote>", after="</quote>")
 help_console <- function(topic, format=c("text", "html", "latex", "Rd"),
-                         lines=NULL, before=NULL, after=NULL) {  
+                         lines=NULL, before=NULL, after=NULL, package = NULL) {  
   format=match.arg(format)
   if (!is.character(topic)) topic <- deparse(substitute(topic))
-  helpfile = utils:::.getHelpFile(help(topic))
+  helpfile = utils:::.getHelpFile(help(topic, package = (package)))
 
   hs <- capture.output(switch(format, 
                               text=tools:::Rd2txt(helpfile),


### PR DESCRIPTION
This allows the `help_console` function to work when two loaded namespaces both contain an identically named exported object, by passing a package name to `utils::help`. The reason for the package value to be written as `(package)` inside `help` is due to non-standard evaluation of the `package` argument (see examples in `? help`). For context and motivation, see [this post on StackOverflow](http://stackoverflow.com/questions/26804298/getting-help-of-r-function-using-help-console-function-from-noamtools-r-package).
